### PR TITLE
CFG Statements and LHS

### DIFF
--- a/ruby.example/Person.rb
+++ b/ruby.example/Person.rb
@@ -1,0 +1,20 @@
+class Person
+  def name=(name)
+    puts "Naming your person #{name}!"
+    @name = name
+  end
+
+  alias full_name= name=
+end
+
+p = Person.new
+p.name = "David"        # Naming your person David!
+
+class Person
+  def name=(name)
+    puts "Please use full_name="
+  end
+end
+
+p.name = "Joe"          # Please use full_name=
+p.full_name = "Joe"     # Naming your person Joe!

--- a/ruby.example/test.pp.rb
+++ b/ruby.example/test.pp.rb
@@ -1,0 +1,2 @@
+alias a b ;
+     alias a c 

--- a/ruby.example/test.pp.rb
+++ b/ruby.example/test.pp.rb
@@ -1,2 +1,0 @@
-alias a b ;
-     alias a c 

--- a/ruby.example/test.rb
+++ b/ruby.example/test.rb
@@ -1,1 +1,2 @@
-alias a b
+alias a ab; 
+alias b s;

--- a/ruby.example/test.rb
+++ b/ruby.example/test.rb
@@ -1,2 +1,4 @@
 alias a ab; 
-alias b s;
+alias b s ;
+alias c c;
+alias s s;

--- a/ruby.test/syntax/context-free/PrimaryTest.spt
+++ b/ruby.test/syntax/context-free/PrimaryTest.spt
@@ -1,0 +1,8 @@
+module PrimaryTest
+
+language Ruby
+
+start symbol Primary
+
+
+

--- a/ruby.test/syntax/context-free/StatementTest.spt
+++ b/ruby.test/syntax/context-free/StatementTest.spt
@@ -4,6 +4,16 @@ language Ruby
 
 start symbol Stmt
 
+// EXP
+// TODO
+
+// UNDEF
+
+test Undef ID [[undef testName]] parse succeeds
+test Undef special token [[undef +]] parse succeeds
+test Undef number [[undef 1]] parse fails
+test Undef symbol [[undef :symb]] parse fails
+
 // ALIAS
 
 test Alias ID to ID [[alias testVar testVar2]] parse succeeds
@@ -13,3 +23,37 @@ test Alias special token to ID[[alias + testVar]] parse succeeds
 test Alias special token to special token [[alias - +]] parse succeeds
 test Alias same token [[alias + +]] parse succeeds
 test Alias ID to keyword [[alias testVar if]] parse fails
+test Alias number to ID [[alias 1 testVar]] parse fails
+test Alias ID to number [[alias testVar 1]] parse fails
+test Alias number to number [[alias 1 2]] parse fails
+
+// Logic Statement
+// TODO
+
+// BEGIN
+
+test Begin compound single statement [[BEGIN { alias a b }]] parse succeeds
+test Begin compound multipe statements [[
+	BEGIN {
+		alias a b;
+		alias c b;
+	}
+]] parse succeeds
+test Begin number [[BEGIN { 1 }]] parse fails
+test Begin token [[BEGIN { $ }]] parse fails
+test Begin symbol [[BEGIN { :testSymbol }]] parse fails
+test Begin lowercase [[begin { alias a b }]] parse fails
+
+// END
+
+test End compound single statement [[END { alias a b }]] parse succeeds
+test End compound multipe statements [[
+	END {
+		alias a b;
+		alias c b;
+	}
+]] parse succeeds
+test End number [[END { 1 }]] parse fails
+test End token [[END { $ }]] parse fails
+test End symbol [[END { :testSymbol }]] parse fails
+test End lowercase [[end { alias a b }]] parse fails

--- a/ruby.test/test.spt
+++ b/ruby.test/test.spt
@@ -1,7 +1,0 @@
-module test
-
-language Ruby
-
-test parse [[
-
-]] parse succeeds

--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -1,12 +1,51 @@
 module Argument
 
 imports
+	LeftHandSide
+	Primary
 
 context-free syntax
+
+	Arg.Assign = <<LHS> = <Arg>>
+//	Arg.LHSOp = <<LHS> <OP_ASSIGN> <Arg>> TODO
+	
+	Arg.RangeInc = <<Arg> .. <Arg>>
+	Arg.RangeExc = <<Arg> ... <Arg>>
 
 	Arg.Plus = <<Arg> + <Arg>>
 	Arg.Min = <<Arg> - <Arg>>
 	Arg.Times = <<Arg> * <Arg>>
 	Arg.Quotient = <<Arg> / <Arg>>
+	Arg.Modulo = <<Arg> % <Arg>>
+	Arg.Power = <<Arg> ** <Arg>>
+	Arg.UnPlus = <+ <Arg>>
+	Arg.UnMin = <- <Arg>>
+	
+	Arg.BitOr = <<Arg> | <Arg>>
+	Arg.BitXOr = <<Arg> ^ <Arg>>
+	Arg.BitAnd = <<Arg> & <Arg>>
+	
+	Arg.SpaceShip = [[Arg] <=> [Arg]]
+	Arg.Greater = [[Arg] > [Arg]]
+	Arg.GreaterEq = [[Arg] >= [Arg]]
+	Arg.Lesser = [[Arg] < [Arg]]
+	Arg.LesserEq = [[Arg] <= [Arg]]
+	Arg.Equals = <<Arg> == <Arg>>
+	Arg.CaseEq = <<Arg> === <Arg>>
+	Arg.NotEq = <<Arg> != <Arg>>
+	Arg.PatternMatch = <<Arg> =~ <Arg>>
+	Arg.NotPatternMatch = <<Arg> !~ <Arg>>
+	
+	Arg.Not = <!<Arg>>
+	Arg.BitNot = <~<Arg>>
+	
+	Arg.BitShiftLeft = [[Arg] << [Arg]]
+	Arg.BitShiftRight = [[Arg] >> [Arg]]
+	
+	Arg.BoolAnd = <<Arg> && <Arg>>
+	Arg.BoolOr = <<Arg> || <Arg>>
+	
+	Arg.Defined = <defined? <Arg>>
+	Arg.Primary = <<Primary>>
 	
 	// Much more

--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -8,6 +8,8 @@ imports
 
 context-free syntax
 
+	Arg = "("Arg")"								{bracket}
+
 	Arg.Assign = <<LHS> = <Arg>> 				{right}
 //	Arg.LHSOp = <<LHS> <OP_ASSIGN> <Arg>> TODO
 	

--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -5,8 +5,6 @@ imports
 	Primary
 
 // TODO: Test Arguments
-// Precedence source: https://ruby-doc.org/core-2.2.0/doc/syntax/precedence_rdoc.html
-// Associativity source: https://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Operators
 
 context-free syntax
 

--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -4,6 +4,10 @@ imports
 	LeftHandSide
 	Primary
 
+// TODO: Test Arguments
+// Precedence source: https://ruby-doc.org/core-2.2.0/doc/syntax/precedence_rdoc.html
+// Associativity source: https://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Operators
+
 context-free syntax
 
 	Arg.Assign = <<LHS> = <Arg>>
@@ -13,9 +17,9 @@ context-free syntax
 	Arg.RangeExc = <<Arg> ... <Arg>>
 
 	Arg.Plus = <<Arg> + <Arg>>
-	Arg.Min = <<Arg> - <Arg>>
+	Arg.Minus = <<Arg> - <Arg>>
 	Arg.Times = <<Arg> * <Arg>>
-	Arg.Quotient = <<Arg> / <Arg>>
+	Arg.Division = <<Arg> / <Arg>>
 	Arg.Modulo = <<Arg> % <Arg>>
 	Arg.Power = <<Arg> ** <Arg>>
 	Arg.UnPlus = <+ <Arg>>
@@ -36,7 +40,7 @@ context-free syntax
 	Arg.PatternMatch = <<Arg> =~ <Arg>>
 	Arg.NotPatternMatch = <<Arg> !~ <Arg>>
 	
-	Arg.Not = <!<Arg>>
+	Arg.BoolNot = <!<Arg>>
 	Arg.BitNot = <~<Arg>>
 	
 	Arg.BitShiftLeft = [[Arg] << [Arg]]
@@ -47,5 +51,7 @@ context-free syntax
 	
 	Arg.Defined = <defined? <Arg>>
 	Arg.Primary = <<Primary>>
+		
+		
 	
-	// Much more
+	

--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -10,46 +10,47 @@ imports
 
 context-free syntax
 
-	Arg.Assign = <<LHS> = <Arg>>
+	Arg.Assign = <<LHS> = <Arg>> 				{right}
 //	Arg.LHSOp = <<LHS> <OP_ASSIGN> <Arg>> TODO
 	
-	Arg.RangeInc = <<Arg> .. <Arg>>
-	Arg.RangeExc = <<Arg> ... <Arg>>
+	Arg.RangeInc = <<Arg> .. <Arg>>				{non-assoc}
+	Arg.RangeExc = <<Arg> ... <Arg>>			{non-assoc}
 
-	Arg.Plus = <<Arg> + <Arg>>
-	Arg.Minus = <<Arg> - <Arg>>
-	Arg.Times = <<Arg> * <Arg>>
-	Arg.Division = <<Arg> / <Arg>>
-	Arg.Modulo = <<Arg> % <Arg>>
-	Arg.Power = <<Arg> ** <Arg>>
-	Arg.UnPlus = <+ <Arg>>
-	Arg.UnMin = <- <Arg>>
+	Arg.Plus = <<Arg> + <Arg>> 					{left}
+	Arg.Minus = <<Arg> - <Arg>> 				{left}
+	Arg.Times = <<Arg> * <Arg>>					{left}
+	Arg.Division = <<Arg> / <Arg>> 				{left}
+	Arg.Modulo = <<Arg> % <Arg>>				{left}
+	Arg.Power = <<Arg> ** <Arg>>				{right}
+	Arg.UnPlus = <+ <Arg>>						{right}
+	Arg.UnMin = <- <Arg>>						{right}
 	
-	Arg.BitOr = <<Arg> | <Arg>>
-	Arg.BitXOr = <<Arg> ^ <Arg>>
-	Arg.BitAnd = <<Arg> & <Arg>>
+	Arg.BitOr = <<Arg> | <Arg>>					{left}
+	Arg.BitXOr = <<Arg> ^ <Arg>>				{left}
+	Arg.BitAnd = <<Arg> & <Arg>>				{left}
 	
-	Arg.SpaceShip = [[Arg] <=> [Arg]]
-	Arg.Greater = [[Arg] > [Arg]]
-	Arg.GreaterEq = [[Arg] >= [Arg]]
-	Arg.Lesser = [[Arg] < [Arg]]
-	Arg.LesserEq = [[Arg] <= [Arg]]
-	Arg.Equals = <<Arg> == <Arg>>
-	Arg.CaseEq = <<Arg> === <Arg>>
-	Arg.NotEq = <<Arg> != <Arg>>
-	Arg.PatternMatch = <<Arg> =~ <Arg>>
-	Arg.NotPatternMatch = <<Arg> !~ <Arg>>
+	Arg.SpaceShip = [[Arg] <=> [Arg]] 			{non-assoc}
+	Arg.Greater = [[Arg] > [Arg]]				{left}
+	Arg.GreaterEq = [[Arg] >= [Arg]] 			{left}
+	Arg.Lesser = [[Arg] < [Arg]] 				{left}
+	Arg.LesserEq = [[Arg] <= [Arg]]				{left}
+	Arg.Equals = <<Arg> == <Arg>> 				{non-assoc}
+	Arg.CaseEq = <<Arg> === <Arg>> 				{non-assoc}
+	Arg.NotEq = <<Arg> != <Arg>> 				{non-assoc}
+	Arg.PatternMatch = <<Arg> =~ <Arg>> 		{non-assoc}
+	Arg.NotPatternMatch = <<Arg> !~ <Arg>> 		{non-assoc}
 	
-	Arg.BoolNot = <!<Arg>>
-	Arg.BitNot = <~<Arg>>
+	Arg.BoolNot = <!<Arg>>						{right}
+	Arg.BitNot = <~<Arg>>						{right}
 	
-	Arg.BitShiftLeft = [[Arg] << [Arg]]
-	Arg.BitShiftRight = [[Arg] >> [Arg]]
+	Arg.BitShiftLeft = [[Arg] << [Arg]] 		{left}
+	Arg.BitShiftRight = [[Arg] >> [Arg]] 		{left}
 	
-	Arg.BoolAnd = <<Arg> && <Arg>>
-	Arg.BoolOr = <<Arg> || <Arg>>
+	Arg.BoolAnd = <<Arg> && <Arg>> 				{left}
+	Arg.BoolOr = <<Arg> || <Arg>> 				{left}
 	
-	Arg.Defined = <defined? <Arg>>
+	Arg.Defined = <defined? <Arg>> 				{non-assoc}
+	
 	Arg.Primary = <<Primary>>
 		
 		

--- a/ruby/syntax/context_free/CompoundStatement.sdf3
+++ b/ruby/syntax/context_free/CompoundStatement.sdf3
@@ -9,24 +9,7 @@ context-free syntax
 
 	CStmt.Stmt = <<StatementList?> <T*>>
 	
-	StatementList = <<Stmt> <StatementListEnd*>>
-	StatementListEnd = 
+	StatementList.Head = <<Stmt> <StatementListEnd*>>
+	StatementListEnd.Trailer = 
 		<<T+>
 		 <Stmt>>
-		
-	
-	
-	
-//		compound-statement ::
-//	statement-list ?
-//	separator-list ?
-//	19
-//	20 statement-list ::
-//	statement ( separator-list statement )
-//	∗
-//	21
-//	22 separator-list ::
-//	separator + 23
-//	24 separator ::
-//	25 ;
-//	26 | [ line-terminator here ]

--- a/ruby/syntax/context_free/CompoundStatement.sdf3
+++ b/ruby/syntax/context_free/CompoundStatement.sdf3
@@ -1,0 +1,32 @@
+module CompoundStatement
+
+imports
+	Statement
+	Expression
+	Terminator
+
+context-free syntax
+
+	CStmt.Stmt = <<StatementList?> <T*>>
+	
+	StatementList = <<Stmt> <StatementListEnd*>>
+	StatementListEnd = 
+		<<T+>
+		 <Stmt>>
+		
+	
+	
+	
+//		compound-statement ::
+//	statement-list ?
+//	separator-list ?
+//	19
+//	20 statement-list ::
+//	statement ( separator-list statement )
+//	∗
+//	21
+//	22 separator-list ::
+//	separator + 23
+//	24 separator ::
+//	25 ;
+//	26 | [ line-terminator here ]

--- a/ruby/syntax/context_free/Expression.sdf3
+++ b/ruby/syntax/context_free/Expression.sdf3
@@ -10,7 +10,7 @@ context-free syntax
 	
 	// Operators
 	
-	Exp.Or = <<Exp> or <Exp>>
-	Exp.And = <<Exp> and <Exp>>
-	Exp.Not = <not <Exp>>
-	Exp.Arg = <<Arg>>
+	Exp.Or = <<Exp> or <Exp>>		{left}
+	Exp.And = <<Exp> and <Exp>>		{left}
+	Exp.Not = <not <Exp>>			{right}
+	Exp.Arg = <<Arg>>				

--- a/ruby/syntax/context_free/LeftHandSide.sdf3
+++ b/ruby/syntax/context_free/LeftHandSide.sdf3
@@ -1,0 +1,17 @@
+module LeftHandSide
+
+imports
+	Argument
+	Identifier
+	Primary
+	Variable
+
+context-free syntax
+	// LeftHandSide is defined as the left hand side of 
+	// an assignment expression.
+	
+	LHS.Var = <<Var>>
+	LHS.CallArgs = <<Primary> [<Arg>]> // TODO [ no line-terminator here ] [ no whitespace here ]!
+	LHS.MethodCallDot = <<Primary>.<ID>> // TODO [ no line-terminator here ]!
+	LHS.MethodCallColon = <<Primary>::<ID>> // TODO only 'constant-ids'.
+	LHS.Constant = <::<ID>> // TODO: only 'constant-ids' (uppercase)

--- a/ruby/syntax/context_free/Primary.sdf3
+++ b/ruby/syntax/context_free/Primary.sdf3
@@ -11,3 +11,61 @@ context-free syntax
 	Primary.Literal = <<Literal>>
 	Primary.Var = <<Var>>
 	Primary.Const = <<Primary> :: <ID>>
+	
+//	PRIMARY: "(" COMPSTMT ")"
+//	| LITERAL
+//	| VARIABLE
+//	| PRIMARY :: IDENTIFIER
+//	| :: IDENTIFIER
+//	| PRIMARY "[" [ARGS] "]"
+//	| "[" [ARGS [,]] "]"
+//	| "{" [ARGS | ASSOCS [,]] "}"
+//	| return ["(" [CALL_ARGS] ")"]
+//	| yield ["(" [CALL_ARGS] ")"]
+//	| defined? "(" ARG ")"
+//	| FUNCTION
+//	| FUNCTION "{" ["|" [BLOCK_VAR] "|"] COMPSTMT "}"
+//	| if EXPR THEN
+//	COMPSTMT
+//	{elsif EXPR THEN
+//	COMPSTMT}
+//	[else
+//	COMPSTMT]
+//	end
+//	| unless EXPR THEN
+//	COMPSTMT
+//	[else
+//	COMPSTMT]
+//	end
+//	| while EXPR DO COMPSTMT end
+//	| until EXPR DO COMPSTMT end
+//	| case COMPSTMT
+//	when WHEN_ARGS THEN COMPSTMT
+//	{when WHEN_ARGS THEN COMPSTMT}
+//	[else
+//	COMPSTMT]
+//	end
+//	| for BLOCK_VAR in EXPR DO
+//	COMPSTMT
+//	end
+//	| begin
+//	COMPSTMT
+//	{rescue [ARGS] DO
+//	COMPSTMT}
+//	[else
+//	COMPSTMT]
+//	[ensure
+//	COMPSTMT]
+//	end
+//	| class IDENTIFIER [< IDENTIFIER]
+//	COMPSTMT
+//	end
+//	| module IDENTIFIER
+//	COMPSTMT
+//	end
+//	| def FNAME ARGDECL
+//	COMPSTMT
+//	end
+//	| def SINGLETON (. | ::) FNAME ARGDECL
+//	COMPSTMT
+//	end

--- a/ruby/syntax/context_free/Primary.sdf3
+++ b/ruby/syntax/context_free/Primary.sdf3
@@ -8,6 +8,6 @@ imports
 // Primary stands for the primary expressions in Ruby 
 context-free syntax
 
-	Prim.Literal = <<Literal>>
-	Prim.Var = <<Var>>
-	Prim.Const = <<Prim> :: <ID>>
+	Primary.Literal = <<Literal>>
+	Primary.Var = <<Var>>
+	Primary.Const = <<Primary> :: <ID>>

--- a/ruby/syntax/context_free/Priorities.sdf3
+++ b/ruby/syntax/context_free/Priorities.sdf3
@@ -81,4 +81,6 @@ context-free priorities
 //		if
 //		unless
 //		while
-//		until }
+//		until } >
+//	{
+//		{}-blocks }

--- a/ruby/syntax/context_free/Priorities.sdf3
+++ b/ruby/syntax/context_free/Priorities.sdf3
@@ -4,6 +4,9 @@ imports
 	Argument
 	Expression
 	
+// Precedence source: http://ruby-doc.org/core-2.5.1/doc/syntax/precedence_rdoc.html
+// Associativity source: https://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Operators
+	
 context-free priorities
 
 	{right: 

--- a/ruby/syntax/context_free/Priorities.sdf3
+++ b/ruby/syntax/context_free/Priorities.sdf3
@@ -1,0 +1,81 @@
+module Priorities
+
+imports
+	Argument
+	Expression
+	
+context-free priorities
+
+	{right: 
+		Arg.BoolNot
+		Arg.BitNot
+		Arg.UnPlus
+		Arg.Power } >
+	{right:
+		Arg.UnMin } >
+	{left:
+		Arg.Times
+		Arg.Division
+		Arg.Modulo } >
+	{left:
+		Arg.Plus
+		Arg.Minus } >
+	{left:
+		Arg.BitShiftLeft
+		Arg.BitShiftRight } >
+	{left:
+		Arg.BitAnd } >
+	{left:
+		Arg.BitOr
+		Arg.BitXOr } >
+	{left:
+		Arg.Lesser
+		Arg.LesserEq
+		Arg.Greater
+		Arg.GreaterEq } >
+	{non-assoc:
+		Arg.Equals
+		Arg.CaseEq
+		Arg.NotEq
+		Arg.PatternMatch
+		Arg.NotPatternMatch
+		Arg.SpaceShip } >
+	{left:
+		Arg.BoolAnd } >
+	{left:
+		Arg.BoolOr } >
+	{non-assoc:
+		Arg.RangeInc
+		Arg.RangeExc } >
+//	{right:
+//		?: } >
+//	{left:
+//		rescue } >
+	{right:
+		Arg.Assign
+		// **=
+		// *= 
+		// /=
+		// %=
+		// +=
+		// -=
+		// <<=
+		// >>=
+		// &&=
+		// &=
+		// ||=
+		// |=
+		// ^=	
+	} >
+	{non-assoc:
+		Arg.Defined } >
+	{right:
+		Exp.Not } >
+	{left:
+		Exp.And 
+		Exp.Or } 
+//	{non-assoc
+//		if
+//		unless
+//		while
+//		until }

--- a/ruby/syntax/context_free/Program.sdf3
+++ b/ruby/syntax/context_free/Program.sdf3
@@ -1,10 +1,10 @@
 module Program
 
 imports
-	Statement
+	CompoundStatement
 
 context-free syntax
 
 	Program.Program = <
-		<Stmt>
+		<CStmt>
 	>

--- a/ruby/syntax/context_free/Statement.sdf3
+++ b/ruby/syntax/context_free/Statement.sdf3
@@ -1,9 +1,27 @@
 module Statement
 
 imports
+	CompoundStatement
+	Expression
 	FunctionName
 	Literal
-
+	
 context-free syntax
 
+	Stmt.Exp = <<Exp>>
+
+	//Stmt.Call = <<Call> do [| [<BlockVar>] |] <CStmt> end>
+	Stmt.Undef = <undef <FNAME>>
 	Stmt.Alias = <alias <FNAME> <FNAME>>
+	
+	Stmt.If = <<Stmt> if <Exp>>
+	Stmt.While = <<Stmt> while <Exp>>
+	Stmt.Unless = <<Stmt> unless <Exp>>
+	Stmt.Until = <<Stmt> until <Exp>>
+	
+	Stmt.Begin = <BEGIN { <CStmt> }> // Object initializer
+	Stmt.End = <END { <CStmt> }> // Object finalizer
+	
+	//Stmt.Comman = <<LHS> = <Command> [do [| [<BlockVar>] |] <CStmt> end]>
+	
+	

--- a/ruby/syntax/context_free/Terminator.sdf3
+++ b/ruby/syntax/context_free/Terminator.sdf3
@@ -1,0 +1,6 @@
+module Terminator
+
+context-free syntax
+
+	T.SemiColon = ";"
+	T.NewLine = [\n] // Does not work?!


### PR DESCRIPTION
Worked on:
* (Compound)Statement
* LeftHandSide
* Examples and testing

Started with Left Hand Side CFG. This occurs in for instance `LHS = ARG`. Here I noticed something that has to be looked at: the https://www.cse.buffalo.edu/~regan/cse305/RubyBNF.pdf doc does not take into account different kind of identifiers like the _constant-identifier_ which is stated in https://www.ipa.go.jp/files/000011432.pdf . If you look at what LHS can be in there you will notice that it can also be something like `:: constant-identifier` which is not mentioned in the RubyBNF.