### PR TITLE
Add Arguments, precedence, and associativity

### DIFF
--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -1,12 +1,51 @@
 module Argument
 
 imports
+	LeftHandSide
+	Primary
 
 context-free syntax
+
+	Arg.Assign = <<LHS> = <Arg>>
+//	Arg.LHSOp = <<LHS> <OP_ASSIGN> <Arg>> TODO
+	
+	Arg.RangeInc = <<Arg> .. <Arg>>
+	Arg.RangeExc = <<Arg> ... <Arg>>
 
 	Arg.Plus = <<Arg> + <Arg>>
 	Arg.Min = <<Arg> - <Arg>>
 	Arg.Times = <<Arg> * <Arg>>
 	Arg.Quotient = <<Arg> / <Arg>>
+	Arg.Modulo = <<Arg> % <Arg>>
+	Arg.Power = <<Arg> ** <Arg>>
+	Arg.UnPlus = <+ <Arg>>
+	Arg.UnMin = <- <Arg>>
+	
+	Arg.BitOr = <<Arg> | <Arg>>
+	Arg.BitXOr = <<Arg> ^ <Arg>>
+	Arg.BitAnd = <<Arg> & <Arg>>
+	
+	Arg.SpaceShip = [[Arg] <=> [Arg]]
+	Arg.Greater = [[Arg] > [Arg]]
+	Arg.GreaterEq = [[Arg] >= [Arg]]
+	Arg.Lesser = [[Arg] < [Arg]]
+	Arg.LesserEq = [[Arg] <= [Arg]]
+	Arg.Equals = <<Arg> == <Arg>>
+	Arg.CaseEq = <<Arg> === <Arg>>
+	Arg.NotEq = <<Arg> != <Arg>>
+	Arg.PatternMatch = <<Arg> =~ <Arg>>
+	Arg.NotPatternMatch = <<Arg> !~ <Arg>>
+	
+	Arg.Not = <!<Arg>>
+	Arg.BitNot = <~<Arg>>
+	
+	Arg.BitShiftLeft = [[Arg] << [Arg]]
+	Arg.BitShiftRight = [[Arg] >> [Arg]]
+	
+	Arg.BoolAnd = <<Arg> && <Arg>>
+	Arg.BoolOr = <<Arg> || <Arg>>
+	
+	Arg.Defined = <defined? <Arg>>
+	Arg.Primary = <<Primary>>
 	
 	// Much more

--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -8,6 +8,8 @@ imports
 
 context-free syntax
 
+	Arg = "("Arg")"								{bracket}
+
 	Arg.Assign = <<LHS> = <Arg>> 				{right}
 //	Arg.LHSOp = <<LHS> <OP_ASSIGN> <Arg>> TODO
 	

--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -5,8 +5,6 @@ imports
 	Primary
 
 // TODO: Test Arguments
-// Precedence source: https://ruby-doc.org/core-2.2.0/doc/syntax/precedence_rdoc.html
-// Associativity source: https://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Operators
 
 context-free syntax
 

--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -4,6 +4,10 @@ imports
 	LeftHandSide
 	Primary
 
+// TODO: Test Arguments
+// Precedence source: https://ruby-doc.org/core-2.2.0/doc/syntax/precedence_rdoc.html
+// Associativity source: https://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Operators
+
 context-free syntax
 
 	Arg.Assign = <<LHS> = <Arg>>
@@ -13,9 +17,9 @@ context-free syntax
 	Arg.RangeExc = <<Arg> ... <Arg>>
 
 	Arg.Plus = <<Arg> + <Arg>>
-	Arg.Min = <<Arg> - <Arg>>
+	Arg.Minus = <<Arg> - <Arg>>
 	Arg.Times = <<Arg> * <Arg>>
-	Arg.Quotient = <<Arg> / <Arg>>
+	Arg.Division = <<Arg> / <Arg>>
 	Arg.Modulo = <<Arg> % <Arg>>
 	Arg.Power = <<Arg> ** <Arg>>
 	Arg.UnPlus = <+ <Arg>>
@@ -36,7 +40,7 @@ context-free syntax
 	Arg.PatternMatch = <<Arg> =~ <Arg>>
 	Arg.NotPatternMatch = <<Arg> !~ <Arg>>
 	
-	Arg.Not = <!<Arg>>
+	Arg.BoolNot = <!<Arg>>
 	Arg.BitNot = <~<Arg>>
 	
 	Arg.BitShiftLeft = [[Arg] << [Arg]]
@@ -47,5 +51,7 @@ context-free syntax
 	
 	Arg.Defined = <defined? <Arg>>
 	Arg.Primary = <<Primary>>
+		
+		
 	
-	// Much more
+	

--- a/ruby/syntax/context_free/Argument.sdf3
+++ b/ruby/syntax/context_free/Argument.sdf3
@@ -10,46 +10,47 @@ imports
 
 context-free syntax
 
-	Arg.Assign = <<LHS> = <Arg>>
+	Arg.Assign = <<LHS> = <Arg>> 				{right}
 //	Arg.LHSOp = <<LHS> <OP_ASSIGN> <Arg>> TODO
 	
-	Arg.RangeInc = <<Arg> .. <Arg>>
-	Arg.RangeExc = <<Arg> ... <Arg>>
+	Arg.RangeInc = <<Arg> .. <Arg>>				{non-assoc}
+	Arg.RangeExc = <<Arg> ... <Arg>>			{non-assoc}
 
-	Arg.Plus = <<Arg> + <Arg>>
-	Arg.Minus = <<Arg> - <Arg>>
-	Arg.Times = <<Arg> * <Arg>>
-	Arg.Division = <<Arg> / <Arg>>
-	Arg.Modulo = <<Arg> % <Arg>>
-	Arg.Power = <<Arg> ** <Arg>>
-	Arg.UnPlus = <+ <Arg>>
-	Arg.UnMin = <- <Arg>>
+	Arg.Plus = <<Arg> + <Arg>> 					{left}
+	Arg.Minus = <<Arg> - <Arg>> 				{left}
+	Arg.Times = <<Arg> * <Arg>>					{left}
+	Arg.Division = <<Arg> / <Arg>> 				{left}
+	Arg.Modulo = <<Arg> % <Arg>>				{left}
+	Arg.Power = <<Arg> ** <Arg>>				{right}
+	Arg.UnPlus = <+ <Arg>>						{right}
+	Arg.UnMin = <- <Arg>>						{right}
 	
-	Arg.BitOr = <<Arg> | <Arg>>
-	Arg.BitXOr = <<Arg> ^ <Arg>>
-	Arg.BitAnd = <<Arg> & <Arg>>
+	Arg.BitOr = <<Arg> | <Arg>>					{left}
+	Arg.BitXOr = <<Arg> ^ <Arg>>				{left}
+	Arg.BitAnd = <<Arg> & <Arg>>				{left}
 	
-	Arg.SpaceShip = [[Arg] <=> [Arg]]
-	Arg.Greater = [[Arg] > [Arg]]
-	Arg.GreaterEq = [[Arg] >= [Arg]]
-	Arg.Lesser = [[Arg] < [Arg]]
-	Arg.LesserEq = [[Arg] <= [Arg]]
-	Arg.Equals = <<Arg> == <Arg>>
-	Arg.CaseEq = <<Arg> === <Arg>>
-	Arg.NotEq = <<Arg> != <Arg>>
-	Arg.PatternMatch = <<Arg> =~ <Arg>>
-	Arg.NotPatternMatch = <<Arg> !~ <Arg>>
+	Arg.SpaceShip = [[Arg] <=> [Arg]] 			{non-assoc}
+	Arg.Greater = [[Arg] > [Arg]]				{left}
+	Arg.GreaterEq = [[Arg] >= [Arg]] 			{left}
+	Arg.Lesser = [[Arg] < [Arg]] 				{left}
+	Arg.LesserEq = [[Arg] <= [Arg]]				{left}
+	Arg.Equals = <<Arg> == <Arg>> 				{non-assoc}
+	Arg.CaseEq = <<Arg> === <Arg>> 				{non-assoc}
+	Arg.NotEq = <<Arg> != <Arg>> 				{non-assoc}
+	Arg.PatternMatch = <<Arg> =~ <Arg>> 		{non-assoc}
+	Arg.NotPatternMatch = <<Arg> !~ <Arg>> 		{non-assoc}
 	
-	Arg.BoolNot = <!<Arg>>
-	Arg.BitNot = <~<Arg>>
+	Arg.BoolNot = <!<Arg>>						{right}
+	Arg.BitNot = <~<Arg>>						{right}
 	
-	Arg.BitShiftLeft = [[Arg] << [Arg]]
-	Arg.BitShiftRight = [[Arg] >> [Arg]]
+	Arg.BitShiftLeft = [[Arg] << [Arg]] 		{left}
+	Arg.BitShiftRight = [[Arg] >> [Arg]] 		{left}
 	
-	Arg.BoolAnd = <<Arg> && <Arg>>
-	Arg.BoolOr = <<Arg> || <Arg>>
+	Arg.BoolAnd = <<Arg> && <Arg>> 				{left}
+	Arg.BoolOr = <<Arg> || <Arg>> 				{left}
 	
-	Arg.Defined = <defined? <Arg>>
+	Arg.Defined = <defined? <Arg>> 				{non-assoc}
+	
 	Arg.Primary = <<Primary>>
 		
 		

--- a/ruby/syntax/context_free/Expression.sdf3
+++ b/ruby/syntax/context_free/Expression.sdf3
@@ -10,7 +10,7 @@ context-free syntax
 	
 	// Operators
 	
-	Exp.Or = <<Exp> or <Exp>>
-	Exp.And = <<Exp> and <Exp>>
-	Exp.Not = <not <Exp>>
-	Exp.Arg = <<Arg>>
+	Exp.Or = <<Exp> or <Exp>>		{left}
+	Exp.And = <<Exp> and <Exp>>		{left}
+	Exp.Not = <not <Exp>>			{right}
+	Exp.Arg = <<Arg>>				

--- a/ruby/syntax/context_free/Priorities.sdf3
+++ b/ruby/syntax/context_free/Priorities.sdf3
@@ -81,4 +81,6 @@ context-free priorities
 //		if
 //		unless
 //		while
-//		until }
+//		until } >
+//	{
+//		{}-blocks }

--- a/ruby/syntax/context_free/Priorities.sdf3
+++ b/ruby/syntax/context_free/Priorities.sdf3
@@ -4,6 +4,9 @@ imports
 	Argument
 	Expression
 	
+// Precedence source: http://ruby-doc.org/core-2.5.1/doc/syntax/precedence_rdoc.html
+// Associativity source: https://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Operators
+	
 context-free priorities
 
 	{right: 

--- a/ruby/syntax/context_free/Priorities.sdf3
+++ b/ruby/syntax/context_free/Priorities.sdf3
@@ -1,0 +1,81 @@
+module Priorities
+
+imports
+	Argument
+	Expression
+	
+context-free priorities
+
+	{right: 
+		Arg.BoolNot
+		Arg.BitNot
+		Arg.UnPlus
+		Arg.Power } >
+	{right:
+		Arg.UnMin } >
+	{left:
+		Arg.Times
+		Arg.Division
+		Arg.Modulo } >
+	{left:
+		Arg.Plus
+		Arg.Minus } >
+	{left:
+		Arg.BitShiftLeft
+		Arg.BitShiftRight } >
+	{left:
+		Arg.BitAnd } >
+	{left:
+		Arg.BitOr
+		Arg.BitXOr } >
+	{left:
+		Arg.Lesser
+		Arg.LesserEq
+		Arg.Greater
+		Arg.GreaterEq } >
+	{non-assoc:
+		Arg.Equals
+		Arg.CaseEq
+		Arg.NotEq
+		Arg.PatternMatch
+		Arg.NotPatternMatch
+		Arg.SpaceShip } >
+	{left:
+		Arg.BoolAnd } >
+	{left:
+		Arg.BoolOr } >
+	{non-assoc:
+		Arg.RangeInc
+		Arg.RangeExc } >
+//	{right:
+//		?: } >
+//	{left:
+//		rescue } >
+	{right:
+		Arg.Assign
+		// **=
+		// *= 
+		// /=
+		// %=
+		// +=
+		// -=
+		// <<=
+		// >>=
+		// &&=
+		// &=
+		// ||=
+		// |=
+		// ^=	
+	} >
+	{non-assoc:
+		Arg.Defined } >
+	{right:
+		Exp.Not } >
+	{left:
+		Exp.And 
+		Exp.Or } 
+//	{non-assoc
+//		if
+//		unless
+//		while
+//		until }


### PR DESCRIPTION
Added precedence and associativity (in a separate file `Priorities.sdf3` and explicit to the syntax rules).

As you can see in the priorities we, also some sugared operators are mentioned on Wikipedia, but not in the Ruby docs.